### PR TITLE
fix(deps): require @automatons/validator ^2.2.0 for OpenAPI 3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@automatons/tools": "^2.0.0",
-    "@automatons/validator": "^2.1.0",
+    "@automatons/validator": "^2.2.0",
     "chalk": "^5.3.0",
     "ora": "^8.1.0",
     "zod": "^4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,10 +45,10 @@
   dependencies:
     js-yaml "^4.1.0"
 
-"@automatons/validator@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@automatons/validator/-/validator-2.1.0.tgz#5d621527695729c36a881381921f2604c3e0edd1"
-  integrity sha512-ZDCIlQIx9mSQkMioIjQPBSNhA1jNWQ5/5WdlDMp+PVOFRD1c0x/ec3h8SrQZZ0o5KNBy2Wd84oUTgzr8lKyXmQ==
+"@automatons/validator@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@automatons/validator/-/validator-2.2.0.tgz#246ae8b41df68c04090495f89801a7660d883514"
+  integrity sha512-/TIp4Hw7j85vripT9bd655pxPBvjq4qdCRLeeQTISkcmsOajhXQsRbtA8rN7tvg6gw4C9xOJAgX3ighEf6LBIA==
   dependencies:
     "@hyperjump/browser" "^1"
     "@hyperjump/json-schema" "^1"


### PR DESCRIPTION
Validator 2.2.0 registers the OpenAPI 3.2 dialect. Bumping the requirement so the CLI validates and generates from documents declaring `openapi: 3.2.x`. No code change; 3.0/3.1 behaviour (incl. the generate.test invalid-schema message) is unchanged.