### PR TITLE
docs: 生成できる generator の一覧に react-query / zod / nestjs を追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,11 @@ Since v2 this package is **ESM-only** and requires **Node.js >= 22**. Use it fro
 ## What code can generate?
 | name | language | type |
 | ---- | -------- | ---- |
-| @automatons/typescript-client-axios | typescript | client (axios) |
-| @automatons/typescript-client-fetch | typescript | client (standard `fetch`) |
+| [@automatons/typescript-client-axios](https://github.com/openapi-automatons/typescript-client-axios) | typescript | client (axios) |
+| [@automatons/typescript-client-fetch](https://github.com/openapi-automatons/typescript-client-fetch) | typescript | client (standard `fetch`) |
+| [@automatons/typescript-client-react-query](https://github.com/openapi-automatons/typescript-client-react-query) | typescript | client (TanStack Query hooks) |
+| [@automatons/typescript-zod](https://github.com/openapi-automatons/typescript-zod) | typescript | schema (zod) |
+| [@automatons/typescript-server-nestjs](https://github.com/openapi-automatons/typescript-server-nestjs) | typescript | server (NestJS) |
 
 ## Get Started
 1. Install library to your project


### PR DESCRIPTION
- What code can generate? の表に公開済みの @automatons/typescript-client-react-query / typescript-zod / typescript-server-nestjs が載っていなかったので追加
- 併せて全行のパッケージ名を各 GitHub リポジトリへのリンクに変更